### PR TITLE
Add fingerprint to payload encryption config

### DIFF
--- a/csharp/Acme.App.MastercardApi.Client.Tests/TokenizeApiTest.cs
+++ b/csharp/Acme.App.MastercardApi.Client.Tests/TokenizeApiTest.cs
@@ -48,6 +48,7 @@ namespace Acme.App.MastercardApi.Client.Tests
                 .WithDecryptionPath("$.encryptedPayload", "$.encryptedPayload.encryptedData")
                 .WithEncryptionCertificate(encryptionCertificate)
                 .WithDecryptionKey(decryptionKey)
+                .WithEncryptionCertificateFingerprint("243E6992EA467F1CBB9973FACFCC3BF17B5CD007")
                 .WithOaepPaddingDigestAlgorithm("SHA-512")
                 .WithEncryptedValueFieldName("encryptedData")
                 .WithEncryptedKeyFieldName("encryptedKey")


### PR DESCRIPTION
Hi~

I setup the necessary credentials correctly, but I got a cryptography error after executing the test project.
https://github.com/Mastercard/mastercard-api-client-tutorial/blob/0c24f778ad57a867eefd8aad44466a49f3f89826/csharp/Acme.App.MastercardApi.Client.Tests/TokenizeApiTest.cs#L17

After a few tries, I figured out the client encryption config is different from the [documentation](https://developer.mastercard.com/mdes-digital-enablement/documentation/api-reference/#encrypt-decrypt-configuration).
https://github.com/Mastercard/mastercard-api-client-tutorial/blob/0c24f778ad57a867eefd8aad44466a49f3f89826/csharp/Acme.App.MastercardApi.Client.Tests/TokenizeApiTest.cs#L44

The sandbox fingerprint value is also from [documentation](https://developer.mastercard.com/mdes-digital-enablement/documentation/tutorials/create-a-new-project/#6-download-client-encryption-key-sandbox).